### PR TITLE
Changes for portable builds on Unix

### DIFF
--- a/src/b_binds.c
+++ b/src/b_binds.c
@@ -1001,7 +1001,7 @@ b_copyline(void)
 	}
 	
 	w_state.clipboardlen = end - begin;
-	w_state.clipboard = reallocarray(w_state.clipboard, end - begin, sizeof(e_char_t));
+	w_state.clipboard = reallocarr(w_state.clipboard, end - begin, sizeof(e_char_t));
 	memcpy(w_state.clipboard, &f->buf[begin], sizeof(e_char_t) * (end - begin));
 }
 
@@ -1024,7 +1024,7 @@ b_cutline(void)
 	f_savecsr(f);
 	
 	w_state.clipboardlen = end - begin;
-	w_state.clipboard = reallocarray(w_state.clipboard, end - begin, sizeof(e_char_t));
+	w_state.clipboard = reallocarr(w_state.clipboard, end - begin, sizeof(e_char_t));
 	memcpy(w_state.clipboard, &f->buf[begin], sizeof(e_char_t) * (end - begin));
 	f_erase(f, begin, end + (end < f->len));
 	
@@ -1088,7 +1088,7 @@ b_ncopyline(void)
 	}
 	
 	w_state.clipboardlen = end - begin;
-	w_state.clipboard = reallocarray(w_state.clipboard, end - begin, sizeof(e_char_t));
+	w_state.clipboard = reallocarr(w_state.clipboard, end - begin, sizeof(e_char_t));
 	memcpy(w_state.clipboard, &f->buf[begin], sizeof(e_char_t) * (end - begin));
 }
 
@@ -1148,7 +1148,7 @@ b_ncutline(void)
 	}
 	
 	w_state.clipboardlen = end - begin;
-	w_state.clipboard = reallocarray(w_state.clipboard, end - begin, sizeof(e_char_t));
+	w_state.clipboard = reallocarr(w_state.clipboard, end - begin, sizeof(e_char_t));
 	memcpy(w_state.clipboard, &f->buf[begin], sizeof(e_char_t) * (end - begin));
 	f_erase(f, begin, end + (end < f->len));
 	

--- a/src/f_frame.c
+++ b/src/f_frame.c
@@ -59,7 +59,7 @@ f_fromfile(OUT f_frame_t *f, char const *file)
 		if (buflen >= bufcap)
 		{
 			bufcap *= 2;
-			buf = reallocarray(buf, bufcap, sizeof(e_char_t));
+			buf = reallocarr(buf, bufcap, sizeof(e_char_t));
 		}
 		
 		buf[buflen++] = ch;
@@ -326,7 +326,7 @@ f_write(f_frame_t *f, e_char_t const *data, u32 pos, usize n)
 	if (newcap != f->cap)
 	{
 		f->cap = newcap;
-		f->buf = reallocarray(f->buf, f->cap, sizeof(e_char_t));
+		f->buf = reallocarr(f->buf, f->cap, sizeof(e_char_t));
 	}
 	
 	memmove(&f->buf[pos + n], &f->buf[pos], sizeof(e_char_t) * (f->len - pos));
@@ -345,7 +345,7 @@ f_write(f_frame_t *f, e_char_t const *data, u32 pos, usize n)
 		if (f->histlen >= f->histcap)
 		{
 			f->histcap *= 2;
-			f->hist = reallocarray(f->hist, f->histcap, sizeof(f_hist_t));
+			f->hist = reallocarr(f->hist, f->histcap, sizeof(f_hist_t));
 		}
 		
 		f->hist[f->histlen++] = (f_hist_t)
@@ -367,7 +367,7 @@ f_erase(f_frame_t *f, u32 lb, u32 ub)
 	f_hist_t *h = f->histlen ? &f->hist[f->histlen - 1] : NULL;
 	if (h && h->type == F_ERASE && h->erase.lb == ub)
 	{
-		h->erase.data = reallocarray(h->erase.data, h->erase.ub - lb, sizeof(e_char_t));
+		h->erase.data = reallocarr(h->erase.data, h->erase.ub - lb, sizeof(e_char_t));
 		memmove(&h->erase.data[ub - lb], h->erase.data, sizeof(e_char_t) * (h->erase.ub - h->erase.lb));
 		memcpy(h->erase.data, &f->buf[lb], sizeof(e_char_t) * (ub - lb));
 		h->erase.lb = lb;
@@ -377,7 +377,7 @@ f_erase(f_frame_t *f, u32 lb, u32 ub)
 		if (f->histlen >= f->histcap)
 		{
 			f->histcap *= 2;
-			f->hist = reallocarray(f->hist, f->histcap, sizeof(f_hist_t));
+			f->hist = reallocarr(f->hist, f->histcap, sizeof(f_hist_t));
 		}
 		
 		e_char_t *data = calloc(ub - lb, sizeof(e_char_t));
@@ -453,7 +453,7 @@ f_breakhist(f_frame_t *f)
 	if (f->len >= f->cap)
 	{
 		f->cap *= 2;
-		f->hist = reallocarray(f->hist, f->cap, sizeof(f_hist_t));
+		f->hist = reallocarr(f->hist, f->cap, sizeof(f_hist_t));
 	}
 	
 	f->hist[f->len++] = (f_hist_t)

--- a/src/i_input.c
+++ b/src/i_input.c
@@ -97,7 +97,7 @@ i_readrawkey(void)
 	if (i_macromode == I_RECMACRO)
 	{
 		++i_macrolen;
-		i_macro = reallocarray(i_macro, i_macrolen, sizeof(e_char_t));
+		i_macro = reallocarr(i_macro, i_macrolen, sizeof(e_char_t));
 		i_macro[i_macrolen - 1] = ch;
 	}
 	

--- a/src/r_render.c
+++ b/src/r_render.c
@@ -268,8 +268,8 @@ r_sigwinch(int arg)
 	r_w = ws.ws_col;
 	r_h = ws.ws_row;
 	
-	r_cellchars = reallocarray(r_cellchars, r_w * r_h, sizeof(e_char_t));
-	r_cellattrs = reallocarray(r_cellattrs, r_w * r_h, sizeof(r_attr_t));
+	r_cellchars = reallocarr(r_cellchars, r_w * r_h, sizeof(e_char_t));
+	r_cellattrs = reallocarr(r_cellattrs, r_w * r_h, sizeof(r_attr_t));
 	
 	r_setbar(r_bar, r_barlen); // recompute bar.
 }

--- a/src/util.c
+++ b/src/util.c
@@ -72,3 +72,26 @@ fileext(char const *path)
 	char const *s = strrchr(path, '.');
 	return s ? s + 1 : "";
 }
+
+bool 
+check_mult_overflow(size_t n1, size_t n2)
+{
+	// should in theory work
+	size_t div1 = SIZE_MAX / n1;
+	if (div1 < n2)
+	{
+		return true;
+	}
+	return false;
+}
+
+void *
+reallocarr(void *ptr, size_t nmemb, size_t size)
+{
+	if (check_mult_overflow(nmemb, size))
+	{
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(ptr, nmemb * size);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -22,3 +22,6 @@ void showerr(char const *fmt, ...);
 u64 fileid(char const *path, bool deref);
 bool ispathsame(char const *patha, char const *pathb);
 char const *fileext(char const *path);
+
+bool check_mult_overflow(size_t n1, size_t n2);
+void *reallocarr(void *ptr, size_t nmemb, size_t size);


### PR DESCRIPTION
- Removed all occurrences of `reallocarray` function, replaced with a `reallocarr` version that should retain the same safety checks.
- Added a function to check whether integer multiplication will overflow

These changes should allow for a portable build across Unix systems.

Author: chickenspaceprogram